### PR TITLE
PR Template, server port, README, codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Goncharo @leite08 @Orta21 @RamilGaripov

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+Ticket: #_[ticket-number]_
+
+### Dependencies
+
+- Upstream: _[this PR points to another PR or depends on its release]_
+- Downstream: _[PRs that depend on this one, either point to this or can only be released after this one is released]_
+
+### Description
+
+_[Document your changes, give context for reviewers, add images/videos of UI changes]_
+
+### Testing
+
+- _[Indicate how you tested this]_

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ First, create a local environment file, to define your Metriport developer API k
 
 ```shell
 $ touch server/app/.env
-$ echo "METRIPORT_API_KEY=<YOUR-API-KEY>" > server/app/.env
-$ echo "METRIPORT_WEBHOOK_KEY=<YOUR-WEBHOOK-KEY>" > server/app/.env
-$ echo "METRIPORT_API_URL=https://api.metriport.com" > server/app/.env
+$ echo "METRIPORT_API_KEY=<YOUR-API-KEY>" >> server/app/.env
+$ echo "METRIPORT_WEBHOOK_KEY=<YOUR-WEBHOOK-KEY>" >> server/app/.env
+$ echo "METRIPORT_API_URL=https://api.metriport.com" >> server/app/.env
 ```
 
 Then to run the full back-end, use docker-compose to lauch a Postgres container, as well as the Node server:
@@ -124,7 +124,7 @@ Then to run the full back-end, use docker-compose to lauch a Postgres container,
 ```shell
 $ cd server/app
 $ npm install # only needs to be run once
-$ docker-compose -f docker-compose.dev.yml up --build # db is on port 5434 and server is on port 8081
+$ docker-compose -f docker-compose.dev.yml up --build # db is on port 5434 and server is on port 8087
 ```
 
 To kill and clean-up the back-end, you can run the following from the `server/app` directory:

--- a/server/app/docker-compose.dev.yml
+++ b/server/app/docker-compose.dev.yml
@@ -19,7 +19,7 @@ services:
       - NODE_ENV=development
       - PORT=8081
     ports:
-      - "8081:8081"
+      - "8087:8081"
       - "9249:9229"
     volumes:
       - ./src:/usr/src/app/src


### PR DESCRIPTION
Found these while reviewing [this PR](https://github.com/metriport/metriport-demo-app/pull/3).

- Update server port so it doesn't conflict w/ other APIs
- Update README (bash to update `.env`)
- Add GH's codeowners
- Add simplified PR template